### PR TITLE
Changed f to F in editorOnlyRenderWhenFocused

### DIFF
--- a/nixos/modules/nixvim/plugins/image.nix
+++ b/nixos/modules/nixvim/plugins/image.nix
@@ -4,7 +4,7 @@
 
     backend = "kitty";
 
-    editorOnlyRenderWhenfocused = false;
+    editorOnlyRenderWhenFocused = false;
 
   };
 }


### PR DESCRIPTION
Fixes build error: plugins.image.editorOnlyRenderWhenfocused does not exist